### PR TITLE
Implement Endpoint to Retrieve a Single Event

### DIFF
--- a/backend/src/events/application/get-event-usecase.ts
+++ b/backend/src/events/application/get-event-usecase.ts
@@ -1,0 +1,18 @@
+import { NotFoundError } from '../../shared';
+import { Event, EventRepository } from '../domain';
+
+class GetEventUseCase {
+  constructor(private eventRepository: EventRepository) {}
+
+  async run(id: number): Promise<Event> {
+    const event = await this.eventRepository.getById(id);
+
+    if (!event) {
+      throw new NotFoundError({ message: 'Event not found' });
+    }
+
+    return event;
+  }
+}
+
+export { GetEventUseCase };

--- a/backend/src/events/application/index.ts
+++ b/backend/src/events/application/index.ts
@@ -1,1 +1,2 @@
 export * from './create-event-usecase';
+export * from './get-event-usecase';

--- a/backend/src/events/domain/repositories/event-repository.ts
+++ b/backend/src/events/domain/repositories/event-repository.ts
@@ -2,6 +2,7 @@ import { Event } from '../models';
 
 interface EventRepository {
   create(event: Event): Promise<Event>;
+  getById(id: number): Promise<Event | null>;
 }
 
 export { EventRepository };

--- a/backend/src/events/infrastructure/dependencies.ts
+++ b/backend/src/events/infrastructure/dependencies.ts
@@ -1,11 +1,12 @@
-import { CreateEventUseCase } from '../application';
+import { CreateEventUseCase, GetEventUseCase } from '../application';
 import { PrismaEventRepository } from './event-repository';
 import { EventController } from './rest-api';
 
 const eventRepository = new PrismaEventRepository();
 
 const createEventUseCase = new CreateEventUseCase(eventRepository);
+const getEventUseCase = new GetEventUseCase(eventRepository);
 
-const eventController = new EventController(createEventUseCase);
+const eventController = new EventController(createEventUseCase, getEventUseCase);
 
 export { eventController };

--- a/backend/src/events/infrastructure/event-repository/prisma-event-repository.ts
+++ b/backend/src/events/infrastructure/event-repository/prisma-event-repository.ts
@@ -15,6 +15,10 @@ class PrismaEventRepository implements EventRepository {
       },
     });
   }
+
+  async getById(id: number): Promise<Event | null> {
+    return await prisma.event.findUnique({ where: { id, participants: { every: { eventId: id } } } });
+  }
 }
 
 export { PrismaEventRepository };

--- a/backend/src/events/infrastructure/rest-api/event-controller.ts
+++ b/backend/src/events/infrastructure/rest-api/event-controller.ts
@@ -1,14 +1,27 @@
 import { Request, Response } from 'express';
 
-import { StatusCode } from '../../../shared';
-import { CreateEventUseCase } from '../../application';
+import { BadRequestError, StatusCode } from '../../../shared';
+import { CreateEventUseCase, GetEventUseCase } from '../../application';
 
 class EventController {
-  constructor(private readonly createEventUseCase: CreateEventUseCase) {}
+  constructor(
+    private readonly createEventUseCase: CreateEventUseCase,
+    private readonly getEventUseCase: GetEventUseCase
+  ) {}
 
   async createEvent(req: Request, res: Response) {
     const event = await this.createEventUseCase.run(req.body);
     res.status(StatusCode.CREATED).json(event);
+  }
+
+  async getEvent(req: Request, res: Response) {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+      throw new BadRequestError({ message: 'Event id is not valid' });
+    }
+
+    const event = await this.getEventUseCase.run(id);
+    res.status(StatusCode.OK).json(event);
   }
 }
 

--- a/backend/src/events/infrastructure/rest-api/event-router.ts
+++ b/backend/src/events/infrastructure/rest-api/event-router.ts
@@ -7,5 +7,6 @@ import { eventCreateValidator } from '../validators/event-zod-validator';
 const eventRouter = Router();
 
 eventRouter.post('/', validationMiddleware(eventCreateValidator), eventController.createEvent.bind(eventController));
+eventRouter.get('/:id', eventController.getEvent.bind(eventController));
 
 export { eventRouter };

--- a/backend/tests/events/application/get-event-usecase.test.ts
+++ b/backend/tests/events/application/get-event-usecase.test.ts
@@ -1,0 +1,53 @@
+import { EventRepository, GetEventUseCase } from '../../../src/events';
+import { generateTestData } from '../../utils';
+import { createMockEventRepository } from '../domain/__mocks__/mock-event-repository';
+
+describe('GetEventUseCase', () => {
+  let useCase: GetEventUseCase;
+  let eventRepository: jest.Mocked<EventRepository>;
+
+  beforeEach(() => {
+    eventRepository = createMockEventRepository();
+
+    useCase = new GetEventUseCase(eventRepository);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('run', () => {
+    it('should return the event when it exists', async () => {
+      const eventData = generateTestData('event');
+
+      eventRepository.getById.mockResolvedValue(eventData);
+
+      expect(await useCase.run(eventData.id)).toEqual(eventData);
+
+      expect(eventRepository.getById).toHaveBeenCalledWith(eventData.id);
+      expect(eventRepository.getById).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error when the event does not exist', async () => {
+      eventRepository.getById.mockResolvedValue(null);
+
+      await expect(useCase.run(1)).rejects.toThrow();
+
+      expect(eventRepository.getById).toHaveBeenCalledWith(1);
+      expect(eventRepository.getById).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error when the event retrieval fails', async () => {
+      const eventData = generateTestData('event');
+
+      eventRepository.getById.mockRejectedValue(new Error());
+
+      await expect(useCase.run(eventData.id)).rejects.toThrow();
+
+      expect(eventRepository.getById).toHaveBeenCalledWith(eventData.id);
+      expect(eventRepository.getById).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/tests/events/domain/__mocks__/mock-event-repository.ts
+++ b/backend/tests/events/domain/__mocks__/mock-event-repository.ts
@@ -2,6 +2,7 @@ import { EventRepository } from '../../../../src/events';
 
 const createMockEventRepository = (): jest.Mocked<EventRepository> => ({
   create: jest.fn(),
+  getById: jest.fn(),
 });
 
 export { createMockEventRepository };

--- a/backend/tests/events/infrastructure/event-repository/prisma-event-repository.test.ts
+++ b/backend/tests/events/infrastructure/event-repository/prisma-event-repository.test.ts
@@ -7,6 +7,8 @@ describe('PrismaEventRepository', () => {
 
   beforeEach(() => {
     repository = new PrismaEventRepository();
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -30,6 +32,33 @@ describe('PrismaEventRepository', () => {
 
       await expect(repository.create(eventData)).rejects.toThrow();
       expect(prismaMock.event.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a event when it receives an event id', async () => {
+      const eventData = generateTestData('event');
+
+      prismaMock.event.findUnique.mockResolvedValue(eventData);
+
+      await expect(repository.getById(eventData.id)).resolves.toEqual(eventData);
+      expect(prismaMock.event.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return null when the event does not exist', async () => {
+      prismaMock.event.findUnique.mockImplementation();
+
+      await expect(repository.getById(1)).resolves.toBeUndefined();
+      expect(prismaMock.event.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error when the event retrieval fails', async () => {
+      const eventData = generateTestData('event');
+
+      prismaMock.event.findUnique.mockRejectedValue(new Error());
+
+      await expect(repository.getById(eventData.id)).rejects.toThrow();
+      expect(prismaMock.event.findUnique).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/tests/events/infrastructure/rest-api/event-controller.test.ts
+++ b/backend/tests/events/infrastructure/rest-api/event-controller.test.ts
@@ -1,18 +1,22 @@
 import { getMockReq, getMockRes } from '@jest-mock/express';
 
-import { CreateEventUseCase, EventController } from '../../../../src/events';
+import { CreateEventUseCase, EventController, GetEventUseCase } from '../../../../src/events';
 import { StatusCode } from '../../../../src/shared';
 import { generateTestData } from '../../../utils';
 
 describe('EventController', () => {
   let controller: EventController;
   let createEventUseCase: jest.Mocked<CreateEventUseCase>;
+  let getEventUseCase: jest.Mocked<GetEventUseCase>;
 
   beforeEach(() => {
     createEventUseCase = {
       run: jest.fn(),
     } as unknown as jest.Mocked<CreateEventUseCase>;
-    controller = new EventController(createEventUseCase);
+    getEventUseCase = {
+      run: jest.fn(),
+    } as unknown as jest.Mocked<GetEventUseCase>;
+    controller = new EventController(createEventUseCase, getEventUseCase);
 
     jest.clearAllMocks();
   });
@@ -53,6 +57,53 @@ describe('EventController', () => {
       createEventUseCase.run.mockRejectedValue(new Error());
 
       await expect(controller.createEvent(req, res)).rejects.toThrow();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getEvent', () => {
+    it('should have the event id in the request params', async () => {
+      const id = '1';
+      const req = getMockReq({ params: { id } });
+      const { res } = getMockRes();
+
+      await controller.getEvent(req, res);
+
+      expect(req.params.id).toBeDefined();
+    });
+
+    it('should return the event data in the response when the event is found', async () => {
+      const eventData = generateTestData('event');
+      const req = getMockReq({ params: { id: eventData.id.toString() } });
+      const { res } = getMockRes();
+
+      getEventUseCase.run.mockResolvedValue(eventData);
+
+      await controller.getEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(StatusCode.OK);
+      expect(res.json).toHaveBeenCalledWith(eventData);
+    });
+
+    it('should throw an error when the event id is not valid', async () => {
+      const id = 'invalid';
+      const req = getMockReq({ params: { id } });
+      const { res } = getMockRes();
+
+      await expect(controller.getEvent(req, res)).rejects.toThrow();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error when the event is not found', async () => {
+      const id = '1';
+      const req = getMockReq({ params: { id } });
+      const { res } = getMockRes();
+
+      getEventUseCase.run.mockRejectedValue(new Error());
+
+      await expect(controller.getEvent(req, res)).rejects.toThrow();
       expect(res.status).not.toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
**Description:**
A new endpoint has been added to the backend to allow users to view the details of a specific event by its ID. This includes:

- Endpoint: A specific endpoint for retrieving a single event by its ID.
- Data Fetching: Retrieves the event data from the database.
- Response: Returns the event details in a structured format.

**Screenshots:**
None

**Additional notes:**
None
