### PR TITLE
Fix Environment Variables Issue in Frontend CD

### DIFF
--- a/.github/workflows/CD-frontend.yaml
+++ b/.github/workflows/CD-frontend.yaml
@@ -30,6 +30,8 @@ jobs:
         with:
           context: ./frontend
           file: ./frontend/Dockerfile.prod
+          build-args: |
+            NEXT_PUBLIC_APP_API_URL=${{ secrets.NEXT_PUBLIC_APP_API_URL }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,8 +14,8 @@ app.use(cors());
 
 app.use(currentUserMiddleware.handle.bind(currentUserMiddleware));
 
-app.use('/users', userRouter);
-app.use('/events', eventRouter);
+app.use('/api/users', userRouter);
+app.use('/api/events', eventRouter);
 
 app.use(errorMiddleware.handle.bind(errorMiddleware));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,9 @@ services:
     container_name: event-platform-frontend
     build:
       context: ./frontend
-      dockerfile: Dockerfile.prod
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_APP_API_URL: ${NEXT_PUBLIC_APP_API_URL}
     restart: always
     ports:
       - '3000:3000'

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -22,6 +22,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# Environment variables
+ARG NEXT_PUBLIC_APP_API_URL
+ENV NEXT_PUBLIC_APP_API_URL=$NEXT_PUBLIC_APP_API_URL
+
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -12,4 +12,13 @@ server {
         	proxy_set_header Host $host;
         	proxy_cache_bypass $http_upgrade;
 	}
+	
+	location /api {
+		proxy_pass http://localhost:4000;
+        	proxy_http_version 1.1;
+        	proxy_set_header Upgrade $http_upgrade;
+        	proxy_set_header Connection 'upgrade';
+        	proxy_set_header Host $host;
+        	proxy_cache_bypass $http_upgrade;
+	}
 }

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -13,6 +13,15 @@ server {
         	proxy_cache_bypass $http_upgrade;
 	}
 	
+	location /api/auth {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
 	location /api {
 		proxy_pass http://localhost:4000;
         	proxy_http_version 1.1;


### PR DESCRIPTION
**Description:**
The frontend application was not reading environment variables correctly on the DigitalOcean droplet, causing requests to the backend to be malformed. This has been fixed in the continuous deployment (CD) process for the frontend.

**Screenshots:**
None

**Additional notes:**
It is mandatory to create a new GitHub secret in order to run de CD frontend workflow correctly.