### PR TITLE
Allow Functionality to Edit an Event

### DIFF
--- a/frontend/__mocks__/repositories.ts
+++ b/frontend/__mocks__/repositories.ts
@@ -9,6 +9,7 @@ const createMockEventRepository = (): jest.Mocked<EventRepository> => ({
   create: jest.fn(),
   getAll: jest.fn(),
   getById: jest.fn(),
+  update: jest.fn(),
 });
 
 export { createMockEventRepository, createMockUserRepository };

--- a/frontend/__tests__/components/modules/events/update-event-form.test.tsx
+++ b/frontend/__tests__/components/modules/events/update-event-form.test.tsx
@@ -1,0 +1,254 @@
+import { UpdateEventForm } from '@/components';
+import { useRequest } from '@/hooks';
+import { setFormError, toastError } from '@/lib';
+import { faker } from '@faker-js/faker';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  act,
+  fireEvent,
+  generateTestData,
+  render,
+  screen,
+  waitFor,
+} from '../../../../__utils__';
+
+jest.mock('@/components/ui/date-time', () => ({
+  ...jest.requireActual('@/components/ui/date-time'),
+  DateTimePicker: ({ onJsDateChange, jsDate, defaultValue }: any) => (
+    <input
+      data-testid='date-time-picker'
+      value={jsDate || ''}
+      onChange={(e) => onJsDateChange(new Date(e.target.value))}
+    />
+  ),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock('@/hooks');
+jest.mock('sonner');
+jest.mock('@/lib');
+
+describe('UpdateEventForm', () => {
+  const useRequestMock = useRequest as jest.Mock;
+  const useRouterMock = useRouter as jest.Mock;
+  const doRequestMock = jest.fn();
+  const pushMock = jest.fn();
+  const event = generateTestData('event');
+
+  beforeEach(() => {
+    useRequestMock.mockReturnValue({
+      doRequest: doRequestMock,
+      loading: false,
+    });
+    useRouterMock.mockReturnValue({ push: pushMock });
+  });
+
+  describe('Rendering', () => {
+    it('should render all form fields', () => {
+      render(<UpdateEventForm event={event} />);
+
+      expect(screen.getByLabelText(/Title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Comunity/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Image/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Location/i)).toBeInTheDocument();
+      expect(screen.getByText(/Event Date/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Publish Event/i)).toBeInTheDocument();
+    });
+
+    it('should render the submit button', () => {
+      render(<UpdateEventForm event={event} />);
+      expect(
+        screen.getByRole('button', { name: /update event/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form validation', () => {
+    it('should display error messages for empty fields', async () => {
+      render(<UpdateEventForm event={event} />);
+
+      await userEvent.clear(screen.getByLabelText(/Title/i));
+      await userEvent.clear(screen.getByLabelText(/Description/i));
+      await userEvent.clear(screen.getByLabelText(/Comunity/i));
+      await userEvent.clear(screen.getByLabelText(/Image/i));
+      await userEvent.clear(screen.getByLabelText(/Location/i));
+      await userEvent.click(screen.getByLabelText(/Publish Event/i));
+      act(() => {
+        fireEvent.change(screen.getByTestId('date-time-picker'), {
+          target: { value: null },
+        });
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /update event/i }));
+
+      expect(
+        await screen.findAllByText(
+          'String must contain at least 3 character(s)'
+        )
+      ).toHaveLength(4);
+      expect(await screen.findByText('Invalid date')).toBeInTheDocument();
+    });
+
+    it('should display error message for invalid image url', async () => {
+      render(<UpdateEventForm event={event} />);
+
+      await userEvent.clear(screen.getByLabelText(/Image/i));
+      await userEvent.type(screen.getByLabelText(/Image/i), 'invalid-url');
+      fireEvent.click(screen.getByRole('button', { name: /update event/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Invalid url')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Form submission', () => {
+    it('should submit the form with valid data', async () => {
+      render(<UpdateEventForm event={event} />);
+
+      const eventData = generateTestData('event', {
+        date: faker.date.future().toISOString(),
+      });
+
+      await userEvent.clear(screen.getByLabelText(/Title/i));
+      await userEvent.clear(screen.getByLabelText(/Description/i));
+      await userEvent.clear(screen.getByLabelText(/Comunity/i));
+      await userEvent.clear(screen.getByLabelText(/Image/i));
+      await userEvent.clear(screen.getByLabelText(/Location/i));
+
+      await userEvent.type(screen.getByLabelText(/Title/i), eventData.title);
+      await userEvent.type(
+        screen.getByLabelText(/Description/i),
+        eventData.description
+      );
+      await userEvent.type(
+        screen.getByLabelText(/Comunity/i),
+        eventData.comunity
+      );
+      await userEvent.type(
+        screen.getByLabelText(/Image/i),
+        eventData.image || ''
+      );
+      await userEvent.type(
+        screen.getByLabelText(/Location/i),
+        eventData.location
+      );
+      await userEvent.click(screen.getByLabelText(/Publish Event/i));
+      act(() => {
+        fireEvent.change(screen.getByTestId('date-time-picker'), {
+          target: { value: eventData.date },
+        });
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /update event/i }));
+
+      await waitFor(() => {
+        expect(doRequestMock).toHaveBeenCalledTimes(1);
+        expect(doRequestMock).toHaveBeenCalledWith(event.id, {
+          title: eventData.title,
+          description: eventData.description,
+          comunity: eventData.comunity,
+          image: eventData.image,
+          location: eventData.location,
+          date: new Date(eventData.date),
+          published: !event.published,
+        });
+      });
+    });
+
+    it('should display loading state during form submission', async () => {
+      useRequestMock.mockReturnValue({ doRequestMock, loading: true });
+
+      render(<UpdateEventForm event={event} />);
+
+      const submitButton = screen.getByRole('button', {
+        name: /update event/i,
+      });
+
+      expect(submitButton).toBeDisabled();
+      expect(screen.getByTestId('loader')).toBeInTheDocument();
+    });
+
+    it('should handle successful form submission', async () => {
+      useRequestMock.mockImplementation(({ onSuccess }) => {
+        return {
+          doRequest: (...args: unknown[]) => {
+            doRequestMock
+              .mockResolvedValue({})(...args)
+              .then(() => onSuccess());
+          },
+          loading: false,
+        };
+      });
+
+      render(<UpdateEventForm event={event} />);
+
+      const eventData = generateTestData('event', {
+        date: faker.date.future().toISOString(),
+      });
+
+      await userEvent.clear(screen.getByLabelText(/Title/i));
+      await userEvent.type(screen.getByLabelText(/Title/i), eventData.title);
+
+      act(() => {
+        fireEvent.change(screen.getByTestId('date-time-picker'), {
+          target: { value: eventData.date },
+        });
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /update event/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledTimes(1);
+        expect(toast.success).toHaveBeenCalledWith(
+          'Event updated successfully'
+        );
+        expect(pushMock).toHaveBeenCalledTimes(1);
+        expect(pushMock).toHaveBeenCalledWith('/dashboard/events');
+      });
+    });
+
+    it('should handle form submission error', async () => {
+      const error = new Error('An error occurred');
+      useRequestMock.mockImplementation(({ onError }) => {
+        return {
+          doRequest: (...args: unknown[]) => {
+            doRequestMock
+              .mockRejectedValue(error)(...args)
+              .catch(() => onError(error));
+          },
+          loading: false,
+        };
+      });
+
+      render(<UpdateEventForm event={event} />);
+
+      const eventData = generateTestData('event', {
+        date: faker.date.future().toISOString(),
+      });
+
+      await userEvent.clear(screen.getByLabelText(/Title/i));
+      await userEvent.type(screen.getByLabelText(/Title/i), eventData.title);
+
+      act(() => {
+        fireEvent.change(screen.getByTestId('date-time-picker'), {
+          target: { value: eventData.date },
+        });
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /update event/i }));
+
+      await waitFor(() => {
+        expect(toastError).toHaveBeenCalledTimes(1);
+        expect(toastError).toHaveBeenCalledWith(error);
+        expect(setFormError).toHaveBeenCalledTimes(1);
+        expect(setFormError).toHaveBeenCalledWith(error, expect.any(Object));
+      });
+    });
+  });
+});

--- a/frontend/__tests__/modules/events/application/create-event.usecase.test.ts
+++ b/frontend/__tests__/modules/events/application/create-event.usecase.test.ts
@@ -18,7 +18,7 @@ describe('createEventUseCase', () => {
     const eventData: EventCreateData = {
       title: data.title,
       description: data.description,
-      date: data.date,
+      date: new Date(data.date),
       comunity: data.comunity,
       image: data.image,
       location: data.location,
@@ -39,7 +39,7 @@ describe('createEventUseCase', () => {
     const eventData: EventCreateData = {
       title: data.title,
       description: data.description,
-      date: data.date,
+      date: new Date(data.date),
       comunity: data.comunity,
       image: data.image,
       location: data.location,

--- a/frontend/__tests__/modules/events/application/update-event.usecase.test.ts
+++ b/frontend/__tests__/modules/events/application/update-event.usecase.test.ts
@@ -1,0 +1,59 @@
+import {
+  EventRepository,
+  EventUpdateData,
+  updateEventUseCase,
+} from '@/modules';
+import { createMockEventRepository } from '../../../../__mocks__';
+import { generateTestData } from '../../../../__utils__';
+
+describe('updateEventUseCase', () => {
+  let eventRepository: jest.Mocked<EventRepository>;
+
+  beforeEach(() => {
+    eventRepository = createMockEventRepository();
+  });
+
+  it('should return an event when update is successful', async () => {
+    const data = generateTestData('event');
+    const eventData: EventUpdateData = {
+      title: data.title,
+      description: data.description,
+      date: new Date(data.date),
+      comunity: data.comunity,
+      image: data.image,
+      location: data.location,
+      published: data.published,
+    };
+    eventRepository.update.mockResolvedValue(data);
+
+    const updateEvent = updateEventUseCase(eventRepository);
+    const response = await updateEvent(data.id, eventData);
+
+    expect(response).toEqual(data);
+    expect(eventRepository.update).toHaveBeenCalledTimes(1);
+    expect(eventRepository.update).toHaveBeenCalledWith(data.id, eventData);
+  });
+
+  it('should throw an error when update fails', async () => {
+    const data = generateTestData('event');
+    const eventData: EventUpdateData = {
+      title: data.title,
+      description: data.description,
+      date: new Date(data.date),
+      comunity: data.comunity,
+      image: data.image,
+      location: data.location,
+      published: data.published,
+    };
+    const error = new Error('Failed to update event');
+    eventRepository.update.mockRejectedValue(error);
+
+    const updateEvent = updateEventUseCase(eventRepository);
+
+    await expect(updateEvent(data.id, eventData)).rejects.toThrow(
+      error.message
+    );
+    expect(eventRepository.update).toHaveBeenCalledTimes(1);
+    expect(eventRepository.update).toHaveBeenCalledWith(data.id, eventData);
+  });
+});

--- a/frontend/__tests__/modules/events/infrastructure/repositories/api-event.repository.test.ts
+++ b/frontend/__tests__/modules/events/infrastructure/repositories/api-event.repository.test.ts
@@ -1,4 +1,9 @@
-import { APIError, apiEventRepository, EventCreateData } from '@/modules';
+import {
+  APIError,
+  apiEventRepository,
+  EventCreateData,
+  EventUpdateData,
+} from '@/modules';
 import fetchMock from 'jest-fetch-mock';
 import { generateTestData } from '../../../../../__utils__';
 
@@ -12,7 +17,7 @@ describe('apiEventRepository', () => {
       const data = generateTestData('event');
       const createData: EventCreateData = {
         comunity: data.comunity,
-        date: data.date,
+        date: new Date(data.date),
         description: data.description,
         image: data.image,
         location: data.location,
@@ -33,7 +38,7 @@ describe('apiEventRepository', () => {
       const data = generateTestData('event');
       const createData: EventCreateData = {
         comunity: data.comunity,
-        date: data.date,
+        date: new Date(data.date),
         description: data.description,
         image: data.image,
         location: data.location,
@@ -57,7 +62,7 @@ describe('apiEventRepository', () => {
       const data = generateTestData('event');
       const createData: EventCreateData = {
         comunity: data.comunity,
-        date: data.date,
+        date: new Date(data.date),
         description: data.description,
         image: data.image,
         location: data.location,
@@ -149,6 +154,75 @@ describe('apiEventRepository', () => {
       const getById = apiEventRepository().getById;
 
       await expect(getById(id)).rejects.toThrow(error.message);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should return an event when update is successful', async () => {
+      const data = generateTestData('event');
+      const id = data.id;
+      const updateData: EventUpdateData = {
+        comunity: data.comunity,
+        date: new Date(data.date),
+        description: data.description,
+        image: data.image,
+        location: data.location,
+        published: data.published,
+        title: data.title,
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(data));
+
+      const update = apiEventRepository().update;
+      const result = await update(id, updateData);
+
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(data));
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an API error when update fails', async () => {
+      const data = generateTestData('event');
+      const id = data.id;
+      const updateData: EventUpdateData = {
+        comunity: data.comunity,
+        date: new Date(data.date),
+        description: data.description,
+        image: data.image,
+        location: data.location,
+        published: data.published,
+        title: data.title,
+      };
+      const apiError = generateTestData('apiError');
+      const { errors, statusCode } = apiError;
+
+      fetchMock.mockResponseOnce(JSON.stringify({ errors }), {
+        status: statusCode,
+      });
+
+      const update = apiEventRepository().update;
+
+      await expect(update(id, updateData)).rejects.toThrow(APIError);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error when fetch fails', async () => {
+      const data = generateTestData('event');
+      const id = data.id;
+      const updateData: EventUpdateData = {
+        comunity: data.comunity,
+        date: new Date(data.date),
+        description: data.description,
+        image: data.image,
+        location: data.location,
+        published: data.published,
+        title: data.title,
+      };
+      const error = new Error('Failed to fetch');
+      fetchMock.mockRejectOnce(error);
+
+      const update = apiEventRepository().update;
+
+      await expect(update(id, updateData)).rejects.toThrow(error.message);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
   });

--- a/frontend/src/app/dashboard/events/[id]/page.tsx
+++ b/frontend/src/app/dashboard/events/[id]/page.tsx
@@ -1,0 +1,30 @@
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  UpdateEventForm,
+} from '@/components';
+import { eventRepository, getEventUseCase } from '@/modules';
+
+interface UpdateEventProps {
+  params: { id: string };
+}
+
+export default async function UpdateEvent({ params }: UpdateEventProps) {
+  const id = parseInt(params.id);
+  const event = await getEventUseCase(eventRepository)(id);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Update Event</CardTitle>
+        <CardDescription>
+          Have you found a mistake? Update your event here.
+        </CardDescription>
+      </CardHeader>
+
+      <UpdateEventForm event={event} />
+    </Card>
+  );
+}

--- a/frontend/src/components/modules/events/events-columns.tsx
+++ b/frontend/src/components/modules/events/events-columns.tsx
@@ -14,6 +14,7 @@ import { Event } from '@/modules';
 import { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { MoreHorizontalIcon } from 'lucide-react';
+import Link from 'next/link';
 
 export const eventColumns: ColumnDef<Event>[] = [
   {
@@ -75,20 +76,27 @@ export const eventColumns: ColumnDef<Event>[] = [
   },
   {
     id: 'actions',
-    cell: () => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant='ghost' className='h-8 w-8 p-0'>
-            <span className='sr-only'>Open menu</span>
-            <MoreHorizontalIcon className='h-4 w-4' />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuLabel>Actions</DropdownMenuLabel>
-          <DropdownMenuItem>View event details</DropdownMenuItem>
-          <DropdownMenuItem>Edit event</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    ),
+    cell: ({ row }) => {
+      const id = row.original.id;
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant='ghost' className='h-8 w-8 p-0'>
+              <span className='sr-only'>Open menu</span>
+              <MoreHorizontalIcon className='h-4 w-4' />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end'>
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem>
+              <Link href={`/dashboard/events/${id}`}>Edit event</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <Link href={`/${id}`}>View event details</Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
   },
 ];

--- a/frontend/src/components/modules/events/index.ts
+++ b/frontend/src/components/modules/events/index.ts
@@ -1,3 +1,4 @@
 export * from './create-event-form';
 export * from './events-columns';
 export * from './events-data-table';
+export * from './update-event-form';

--- a/frontend/src/components/modules/events/update-event-form.tsx
+++ b/frontend/src/components/modules/events/update-event-form.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import {
+  Button,
+  CardContent,
+  CardFooter,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Switch,
+  Textarea,
+} from '@/components';
+import { DateTimePicker } from '@/components/ui/date-time';
+import { useRequest } from '@/hooks';
+import { setFormError, toastError } from '@/lib';
+import {
+  Event,
+  eventRepository,
+  EventUpdateData,
+  updateEventUseCase,
+} from '@/modules';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z, ZodTypeAny } from 'zod';
+
+type EventUpdateRawShape = Record<keyof EventUpdateData, ZodTypeAny>;
+const formSchema = z.object<EventUpdateRawShape>({
+  comunity: z.string().min(3).trim(),
+  date: z.date({ message: 'Please select a valid date' }).min(new Date()),
+  description: z.string().min(3).trim(),
+  location: z.string().min(3).trim(),
+  title: z.string().min(3).trim(),
+  published: z.boolean().optional(),
+  image: z.union([z.string().url().trim().nullish(), z.literal('')]),
+});
+
+export interface UpdateEventFormProps {
+  event: Event;
+}
+
+const UpdateEventForm: React.FC<UpdateEventFormProps> = (props) => {
+  const { event } = props;
+
+  const router = useRouter();
+
+  const form = useForm<EventUpdateData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      comunity: event.comunity,
+      description: event.description,
+      date: new Date(event.date),
+      image: event.image,
+      location: event.location,
+      published: event.published,
+      title: event.title,
+    },
+  });
+
+  const { doRequest, loading } = useRequest({
+    request: updateEventUseCase(eventRepository),
+    onSuccess: () => {
+      toast.success('Event updated successfully');
+      router.push('/dashboard/events');
+    },
+    onError: (error) => {
+      toastError(error);
+      setFormError(error, form);
+    },
+  });
+
+  const onSubmit: SubmitHandler<EventUpdateData> = (values) => {
+    doRequest(event.id, values);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent className='grid gap-4'>
+          <FormField
+            control={form.control}
+            name='title'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <Input placeholder='My Awesome Event' {...field} />
+                </FormControl>
+                <FormMessage />
+                <FormDescription>
+                  Come on! Give your event a catchy title.
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name='description'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder='Tell us about your amazing event...'
+                    rows={5}
+                    className='resize-none'
+                    {...field}
+                  />
+                </FormControl>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+            <FormField
+              control={form.control}
+              name='comunity'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Comunity</FormLabel>
+                  <FormControl>
+                    <Input placeholder='Open Source Community' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                  <FormDescription>
+                    The name of the community hosting the event.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='image'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Image</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='https://example.com/image.jpg'
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+            <FormField
+              control={form.control}
+              name='location'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Location</FormLabel>
+                  <FormControl>
+                    <Input placeholder='https://youtu.be/...' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                  <FormDescription>
+                    Online or physical location of the event.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='date'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Event Date</FormLabel>
+                  <FormControl>
+                    <DateTimePicker
+                      granularity='second'
+                      jsDate={field.value}
+                      onJsDateChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                  <FormDescription>
+                    When will the event take place?
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+          </div>
+        </CardContent>
+
+        <CardFooter className='border-t px-6 py-4 flex justify-between gap-3'>
+          <Button type='submit' disabled={loading}>
+            {loading && (
+              <Loader2
+                className='mr-2 h-4 w-4 animate-spin'
+                data-testid='loader'
+              />
+            )}
+            Update Event
+          </Button>
+
+          <FormField
+            control={form.control}
+            name='published'
+            render={({ field }) => (
+              <FormItem className='flex items-center space-x-2 space-y-0'>
+                <FormLabel>Publish Event</FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </CardFooter>
+      </form>
+    </Form>
+  );
+};
+
+export { UpdateEventForm };

--- a/frontend/src/modules/events/application/index.ts
+++ b/frontend/src/modules/events/application/index.ts
@@ -1,3 +1,4 @@
 export * from './create-event.usecase';
 export * from './get-event.usecase';
 export * from './get-events.usecase';
+export * from './update-event.usecase';

--- a/frontend/src/modules/events/application/update-event.usecase.ts
+++ b/frontend/src/modules/events/application/update-event.usecase.ts
@@ -1,0 +1,9 @@
+import { Event, EventCreateData, EventRepository } from '../domain';
+
+const updateEventUseCase = (eventRepository: EventRepository) => {
+  return async (id: number, data: EventCreateData): Promise<Event> => {
+    return await eventRepository.update(id, data);
+  };
+};
+
+export { updateEventUseCase };

--- a/frontend/src/modules/events/domain/event.repository.ts
+++ b/frontend/src/modules/events/domain/event.repository.ts
@@ -1,10 +1,11 @@
 import { Event } from './event';
-import { EventCreateData } from './types';
+import { EventCreateData, EventUpdateData } from './types';
 
 interface EventRepository {
   create(data: EventCreateData): Promise<Event>;
   getAll(): Promise<Event[]>;
   getById(id: number): Promise<Event>;
+  update(id: number, data: EventUpdateData): Promise<Event>;
 }
 
 export type { EventRepository };

--- a/frontend/src/modules/events/domain/types/event.data.ts
+++ b/frontend/src/modules/events/domain/types/event.data.ts
@@ -5,4 +5,9 @@ type EventCreateData = Pick<
   'comunity' | 'description' | 'image' | 'location' | 'published' | 'title'
 > & { date: Date | null };
 
-export type { EventCreateData };
+type EventUpdateData = Pick<
+  Event,
+  'comunity' | 'description' | 'image' | 'location' | 'published' | 'title'
+> & { date: Date | null };
+
+export type { EventCreateData, EventUpdateData };

--- a/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
+++ b/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
@@ -35,7 +35,7 @@ const apiEventRepository = (): EventRepository => {
       {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
-        next: { revalidate: 10 },
+        next: { revalidate: 0 },
       }
     );
     const jsonResponse = await response.json();
@@ -51,7 +51,7 @@ const apiEventRepository = (): EventRepository => {
       {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
-        next: { revalidate: 1000 },
+        next: { revalidate: 0 },
       }
     );
     const jsonResponse = await response.json();

--- a/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
+++ b/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
@@ -1,7 +1,12 @@
 import { APIError } from '@/modules';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
-import { Event, EventCreateData, EventRepository } from '../../domain';
+import {
+  Event,
+  EventCreateData,
+  EventRepository,
+  EventUpdateData,
+} from '../../domain';
 
 const apiEventRepository = (): EventRepository => {
   const create = async (data: EventCreateData): Promise<Event> => {
@@ -56,7 +61,23 @@ const apiEventRepository = (): EventRepository => {
     return jsonResponse;
   };
 
-  return { create, getAll, getById };
+  const update = async (id: number, data: EventUpdateData): Promise<Event> => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_APP_API_URL}/events/${id}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }
+    );
+    const jsonResponse = await response.json();
+    if (!response.ok) {
+      throw new APIError({ ...jsonResponse, statusCode: response.status });
+    }
+    return jsonResponse;
+  };
+
+  return { create, getAll, getById, update };
 };
 
 export { apiEventRepository };


### PR DESCRIPTION
**Description:**
To enable users to update details of an existing event, the frontend application has been implemented with a functionality for editing events. This will involve creating an interface for users to modify event information and submit updates to the backend.


**Screenshots:**
![localhost_3000_dashboard_events_3](https://github.com/user-attachments/assets/9f0f0018-1e73-48e4-9216-b91a43c4df10)


**Additional notes:**
None