### PR TITLE
Improve Responsive Design of Event Datatable

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -33,9 +33,7 @@ const config = {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ['/node_modules/', '/src/components/ui/'],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: 'v8',

--- a/frontend/src/components/modules/events/events-columns.tsx
+++ b/frontend/src/components/modules/events/events-columns.tsx
@@ -25,9 +25,11 @@ export const eventColumns: ColumnDef<Event>[] = [
     cell: ({ row }) => {
       const comunity = row.original.comunity;
       return (
-        <div className='flex space-x-2'>
-          <Badge variant='secondary'>{comunity}</Badge>
-          <span className='max-w-[500px] truncate font-medium'>
+        <div className='flex flex-col items-start space-y-2'>
+          <Badge variant='secondary' className='max-w-[150px] line-clamp-1'>
+            {comunity}
+          </Badge>
+          <span className='line-clamp-3 font-medium pl-2.5'>
             {row.getValue('title')}
           </span>
         </div>

--- a/frontend/src/components/ui/data-table-pagination.tsx
+++ b/frontend/src/components/ui/data-table-pagination.tsx
@@ -24,7 +24,7 @@ const DataTablePagination: <TData>(
   const { table } = props;
 
   return (
-    <div className='flex items-center justify-between px-2'>
+    <div className='flex flex-col space-y-4 items-center justify-between px-2 md:flex-row md:space-y-0'>
       {table.getIsSomeRowsSelected() ? (
         <div className='flex-1 text-sm text-muted-foreground'>
           {table.getFilteredSelectedRowModel().rows.length} of{' '}
@@ -36,7 +36,7 @@ const DataTablePagination: <TData>(
         </div>
       )}
 
-      <div className='flex items-center space-x-6 lg:space-x-8'>
+      <div className='flex flex-col space-y-2 items-center sm:flex-row sm:space-x-6 sm:space-y-0 lg:space-x-8'>
         <div className='flex items-center space-x-2'>
           <p className='text-sm font-medium'>Rows per page</p>
           <Select


### PR DESCRIPTION
**Description:**
Fixing the footer of the event datatable because it overflowed the screen on smaller devices, causing layout issues and reducing usability.

**Screenshots:**
![localhost_3000_dashboard_events](https://github.com/user-attachments/assets/98cb5bb0-1fbe-4a78-ad5e-f1250db64c7f)

**Additional notes:**
None