### PR TITLE
Improve Invalid Credentials Message on Sign-In Form

### DIFF
--- a/frontend/__tests__/modules/users/infrastructure/repositories/api-user.repository.test.ts
+++ b/frontend/__tests__/modules/users/infrastructure/repositories/api-user.repository.test.ts
@@ -62,6 +62,25 @@ describe('apiUserRepository', () => {
       await expect(signIn(signInData)).rejects.toThrow(error.message);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
+
+    it('should throw an error with Unknown error message when response has no errors array', async () => {
+      const data = generateTestData('user');
+      const signInData: UserSignInData = {
+        email: data.email,
+        password: data.password,
+      };
+      const apiError = generateTestData('apiError');
+      const { statusCode } = apiError;
+
+      fetchMock.mockResponseOnce(JSON.stringify({}), {
+        status: statusCode,
+      });
+
+      const signIn = apiUserRepository().signIn;
+
+      await expect(signIn(signInData)).rejects.toThrow('Unknown error');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('signUp', () => {

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -10,9 +10,6 @@ export const handler = NextAuth({
         const response = await signInUseCase(userRepository)(
           credentials as UserSignInData
         );
-        if ('errors' in response) {
-          throw new Error(response.errors[0].message);
-        }
 
         return {
           ...response,

--- a/frontend/src/modules/users/application/signin.usecase.ts
+++ b/frontend/src/modules/users/application/signin.usecase.ts
@@ -1,10 +1,7 @@
-import { CustomError } from '@/modules/shared';
 import { UserRepository, UserSignInData, UserSignInResponse } from '../domain';
 
 const signInUseCase = (userRepository: UserRepository) => {
-  return async (
-    data: UserSignInData
-  ): Promise<UserSignInResponse | CustomError> => {
+  return async (data: UserSignInData): Promise<UserSignInResponse> => {
     return await userRepository.signIn(data);
   };
 };

--- a/frontend/src/modules/users/domain/user.repository.ts
+++ b/frontend/src/modules/users/domain/user.repository.ts
@@ -1,4 +1,3 @@
-import { CustomError } from '@/modules';
 import {
   UserSignInData,
   UserSignInResponse,
@@ -7,7 +6,7 @@ import {
 } from './types';
 
 interface UserRepository {
-  signIn(data: UserSignInData): Promise<UserSignInResponse | CustomError>;
+  signIn(data: UserSignInData): Promise<UserSignInResponse>;
   signUp(data: UserSignUpData): Promise<UserSignUpResponse>;
 }
 

--- a/frontend/src/modules/users/infrastructure/repositories/api-user.repository.ts
+++ b/frontend/src/modules/users/infrastructure/repositories/api-user.repository.ts
@@ -21,7 +21,11 @@ const apiUserRepository = (): UserRepository => {
     );
     const jsonResponse = await response.json();
     if (!response.ok) {
-      throw new APIError(jsonResponse);
+      throw new APIError({
+        message: jsonResponse?.errors?.[0]?.message || 'Unknown error',
+        errors: jsonResponse?.errors || [],
+        statusCode: response.status,
+      });
     }
     return jsonResponse;
   };


### PR DESCRIPTION
**Description:**
When a user provides invalid credentials on the Sign-In form, the error message displayed has been fixed in order to use the correct message which comes from API.

**Screenshots:**
![localhost_3000_ (1)](https://github.com/user-attachments/assets/b445b884-20ab-4202-8768-c28ea1eb5de9)

**Additional notes:**
None