### PR TITLE
Event List Not Updating After Creating or Updating an Event

### DIFF
--- a/frontend/__tests__/components/modules/events/actions.test.ts
+++ b/frontend/__tests__/components/modules/events/actions.test.ts
@@ -1,0 +1,29 @@
+import { revalidateEventsAction } from '@/components';
+import { revalidateTag } from 'next/cache';
+
+jest.mock('next/cache', () => ({
+  revalidateTag: jest.fn(),
+}));
+
+describe('actions', () => {
+  describe('revalidateEventsAction', () => {
+    it('should call revalidateTag with the correct tag', () => {
+      revalidateEventsAction();
+      expect(revalidateTag).toHaveBeenCalledWith('/events');
+    });
+
+    it('should call revalidateTag only once', () => {
+      revalidateEventsAction();
+      expect(revalidateTag).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw any errors', () => {
+      expect(() => revalidateEventsAction()).not.toThrow();
+    });
+
+    it('should return undefined', () => {
+      const result = revalidateEventsAction();
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/frontend/__tests__/components/modules/events/create-event-form.test.tsx
+++ b/frontend/__tests__/components/modules/events/create-event-form.test.tsx
@@ -14,6 +14,10 @@ import {
   waitFor,
 } from '../../../../__utils__';
 
+jest.mock('@/components/modules/events', () => ({
+  ...jest.requireActual('@/components/modules/events'),
+  revalidateEventsAction: jest.fn(),
+}));
 jest.mock('@/components/ui/date-time', () => ({
   ...jest.requireActual('@/components/ui/date-time'),
   DateTimePicker: ({ onJsDateChange, jsDate }: any) => (

--- a/frontend/__tests__/components/modules/events/update-event-form.test.tsx
+++ b/frontend/__tests__/components/modules/events/update-event-form.test.tsx
@@ -14,6 +14,10 @@ import {
   waitFor,
 } from '../../../../__utils__';
 
+jest.mock('@/components/modules/events', () => ({
+  ...jest.requireActual('@/components/modules/events'),
+  revalidateEventsAction: jest.fn(),
+}));
 jest.mock('@/components/ui/date-time', () => ({
   ...jest.requireActual('@/components/ui/date-time'),
   DateTimePicker: ({ onJsDateChange, jsDate, defaultValue }: any) => (

--- a/frontend/src/components/modules/events/actions.ts
+++ b/frontend/src/components/modules/events/actions.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+export const revalidateEventsAction = (): void => {
+  revalidateTag('/events');
+};

--- a/frontend/src/components/modules/events/create-event-form.tsx
+++ b/frontend/src/components/modules/events/create-event-form.tsx
@@ -15,6 +15,7 @@ import {
   Switch,
   Textarea,
 } from '@/components';
+import { revalidateEventsAction } from '@/components/modules/events';
 import { DateTimePicker } from '@/components/ui/date-time';
 import { useRequest } from '@/hooks';
 import { setFormError, toastError } from '@/lib';
@@ -63,6 +64,7 @@ const CreateEventForm: React.FC<CreateEventFormProps> = () => {
   const { doRequest, loading } = useRequest({
     request: createEventUseCase(eventRepository),
     onSuccess: () => {
+      revalidateEventsAction();
       toast.success('Event created successfully');
       router.push('/dashboard/events');
     },

--- a/frontend/src/components/modules/events/index.ts
+++ b/frontend/src/components/modules/events/index.ts
@@ -1,3 +1,4 @@
+export * from './actions';
 export * from './create-event-form';
 export * from './event-article';
 export * from './events-columns';

--- a/frontend/src/components/modules/events/update-event-form.tsx
+++ b/frontend/src/components/modules/events/update-event-form.tsx
@@ -15,6 +15,7 @@ import {
   Switch,
   Textarea,
 } from '@/components';
+import { revalidateEventsAction } from '@/components/modules/events';
 import { DateTimePicker } from '@/components/ui/date-time';
 import { useRequest } from '@/hooks';
 import { setFormError, toastError } from '@/lib';
@@ -68,6 +69,7 @@ const UpdateEventForm: React.FC<UpdateEventFormProps> = (props) => {
   const { doRequest, loading } = useRequest({
     request: updateEventUseCase(eventRepository),
     onSuccess: () => {
+      revalidateEventsAction();
       toast.success('Event updated successfully');
       router.push('/dashboard/events');
     },

--- a/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
+++ b/frontend/src/modules/events/infrastructure/repositories/api-event.repository.ts
@@ -36,7 +36,7 @@ const apiEventRepository = (): EventRepository => {
       {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
-        next: { revalidate: 0 },
+        next: { revalidate: 0, tags: ['/events'] },
       }
     );
     const jsonResponse = await response.json();


### PR DESCRIPTION
**Description:**
When creating or updating an event, the event list did not refresh or revalidate upon returning to the events page. Therefore, a revalidate events by tags has been implemented using the next/cache feature which next.js provides.

**Screenshots:**
None

**Additional notes:**
None